### PR TITLE
fix build error and add check if os.Args len is 1

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func readHosts(hostFile string) []string {
 
 func passwordEntery() string {
 	fmt.Printf("Password: ")
-	getPasss := gopass.GetPasswdMasked()
+	getPasss, _ := gopass.GetPasswdMasked()
 	passwd := string(getPasss[:])
 
 	if len(passwd) == 0 {
@@ -107,6 +107,9 @@ func passwordEntery() string {
 
 func main() {
 	fmt.Println("Usage: command hosts file username")
+	if len(os.Args) <= 1 {
+		os.Exit(1)
+	}
 	hosts := readHosts(os.Args[1])
 	var (
 		User string


### PR DESCRIPTION
Hey, there is a fix for the build error : 
```bash
runcmd(master) » go build main.go
# command-line-arguments
./main.go:98:36: multiple-value gopass.GetPasswdMasked() in single-value context
```

Probably better to check the error instead of ignoring it.

I also added a check to avoid an out-of-range error : 
```bash
Usage: command hosts file username
panic: runtime error: index out of range
goroutine 1 [running]:
insertions(+), 1 deletion(-)
main.main()
        /home/mathieu/Documents/runcmd/runcmd/main.go:110 +0x68e
exit status 2
```